### PR TITLE
Removing #extend_expiration! and fixing #extend_expiration

### DIFF
--- a/lib/signatory/document.rb
+++ b/lib/signatory/document.rb
@@ -2,12 +2,7 @@ module Signatory
   class Document < API::Base
 
     def extend_expiration
-      connection.post(:extend_expiration)
-    end
-
-    def extend_expiration!
-      extend_expiration
-      reload
+      connection.post("#{self.class.site}documents/#{id}/extend_expiration")
     end
 
     def expired?

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -42,29 +42,8 @@ describe Signatory::Document do
     it "should post to the correct action" do
       stub_document('XXXXX')
       doc = Signatory::Document.find('XXXXX')
-      Signatory::Document.connection.should_receive(:post).with(:extend_expiration)
+      Signatory::Document.connection.should_receive(:post).with('https://rightsignature.com/api/documents/XXXXX/extend_expiration')
       doc.extend_expiration
-    end
-  end
-
-  describe "#extend_expiration!" do
-    before :each do
-      stub_document('XXXXX')
-      @doc = Signatory::Document.find('XXXXX')
-    end
-
-    it "should extend the expiration date" do
-      @doc.stub!(:extend_expiration)
-      @doc.stub!(:reload)
-      @doc.should_receive(:extend_expiration)
-      @doc.extend_expiration!
-    end
-
-    it "should reload the document" do
-      @doc.stub!(:extend_expiration)
-      @doc.stub!(:reload)
-      @doc.should_receive(:reload)
-      @doc.extend_expiration!
     end
   end
 


### PR DESCRIPTION
The last request mocked out too much (#reload wasn't working properly), and I also found I had to hack around activeresource a bit to get the extend_expiration POST request to work without letting it try to parse an xml return.

I've added an issue for #reload not working as well.
